### PR TITLE
fixed docker container naming

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -47,7 +47,7 @@ test:
     - echo "Running Docker containers"; docker ps -a
     - echo "Stopping all Docker containers"; docker stop $(docker ps -a -q)
     - mkdir -p $CIRCLE_TEST_REPORTS/docker/
-    - docker logs coderadar_coderadarserver_1 > $CIRCLE_TEST_REPORTS/docker/coderadar-server.log
+    - docker logs coderadar_coderadar-server_1 > $CIRCLE_TEST_REPORTS/docker/coderadar-server.log
 
 deployment:
   hub:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-coderadar:
-  image: "thombergs/coderadar:latest"
+coderadar-server:
+  image: "thombergs/coderadar-server:latest"
   ports:
     - "8080:8080"

--- a/server/coderadar-webapp/build.gradle
+++ b/server/coderadar-webapp/build.gradle
@@ -123,7 +123,7 @@ bootRun {
 task buildDocker(type: Docker, dependsOn: build) {
     push = false
     tagVersion = 'latest'
-    tag = "${project.dockerGroup}/coderadar"
+    tag = "${project.dockerGroup}/coderadar-server"
 
     dockerfile = file('src/main/docker/Dockerfile')
     doFirst {


### PR DESCRIPTION
as there are some errors with the docker naming the circleci build will always fail, as it is not possible to start the referenced image.